### PR TITLE
override configure_permitted_parameters method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,8 @@
 class ApplicationController < ActionController::Base
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  before_filter :configure_permitted_parameters, if: :devise_controller?
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.for(:sign_up) { |u| u.permit(:email, :password, :name, :profile, :work, :group, :avatar) }
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-  before_filter :configure_permitted_parameters, if: :devise_controller?
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.for(:sign_up) { |u| u.permit(:email, :password, :name, :profile, :work, :group, :avatar) }
+    devise_parameter_sanitizer.for(:sign_up) << [:name, :profile, :work, :group, :avatar]
   end
 end


### PR DESCRIPTION
# WHAT

deviseの新規登録時のストロングパラメーターにusersテーブルに定義したカラムを追加。
# WHY

新規登録時にemailとpassword以外の情報も登録をする為。
